### PR TITLE
Remove TextType required

### DIFF
--- a/textractor/validate/validation.py
+++ b/textractor/validate/validation.py
@@ -69,7 +69,7 @@ def validate_word(json_block):
             },
             "Id": {"type": "string"},
         },
-        "required": ["BlockType", "Confidence", "Text", "TextType", "Geometry", "Id"],
+        "required": ["BlockType", "Confidence", "Text",  "Geometry", "Id"],
     }
     validate(instance=json_block, schema=word_schema)
 


### PR DESCRIPTION
Removed "TextType" from required list of Block attributes as per AWS API documentation:  https://docs.aws.amazon.com/textract/latest/dg/API_Block.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
